### PR TITLE
fix: default consume offset

### DIFF
--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(consumeCmd)
-	consumeCmd.Flags().StringVar(&offsetFlag, "offset", "oldest", "Offset to start consuming. Possible values: oldest, newest. Default: newest")
+	consumeCmd.Flags().StringVar(&offsetFlag, "offset", "oldest", "Offset to start consuming. Possible values: oldest, newest.")
 	consumeCmd.Flags().BoolVar(&raw, "raw", false, "Print raw output of messages, without key or prettified JSON")
 	consumeCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Shorthand to start consuming with offset HEAD-1 on each partition. Overrides --offset flag")
 


### PR DESCRIPTION
Current implementation uses oldest as default but documents newest as being the default.

This removes the "Default" from the doc string as it is shown by default. I think this is better than changing the default and surprising people.

Current output:

```sh
--offset string   Offset to start consuming. Possible values: oldest, newest. Default: newest (default "oldest")
```

**IMPORTANT** this is a Github edit commit. I have ZERO go knowledge but I think your tool is very useful! If my changes break anything I will close this and open an issue instead.

Thanks for your work!