### PR TITLE
fix SASL authentication when SSL encryption is not enabled (PLAINTEXT)

### DIFF
--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -22,7 +22,13 @@ func getConfig() (saramaConfig *sarama.Config) {
 	saramaConfig.Version = sarama.V1_0_0_0
 	saramaConfig.Producer.Return.Successes = true
 
-	if cluster := currentCluster; cluster.SecurityProtocol == "SASL_SSL" {
+	cluster := currentCluster
+	if cluster.SASL != nil {
+		saramaConfig.Net.SASL.Enable = true
+		saramaConfig.Net.SASL.User = cluster.SASL.Username
+		saramaConfig.Net.SASL.Password = cluster.SASL.Password
+	}
+	if cluster.SecurityProtocol == "SASL_SSL" {
 		saramaConfig.Net.TLS.Enable = true
 		if cluster.TLS != nil {
 			tlsConfig := &tls.Config{
@@ -43,11 +49,7 @@ func getConfig() (saramaConfig *sarama.Config) {
 		} else {
 			saramaConfig.Net.TLS.Config = &tls.Config{InsecureSkipVerify: false}
 		}
-		saramaConfig.Net.SASL.Enable = true
-		saramaConfig.Net.SASL.User = cluster.SASL.Username
-		saramaConfig.Net.SASL.Password = cluster.SASL.Password
 	}
-
 	return saramaConfig
 }
 

--- a/examples/sasl_plaintext.yaml
+++ b/examples/sasl_plaintext.yaml
@@ -1,0 +1,8 @@
+clusters:
+- name: test
+  brokers:
+  - localhost:9092
+  SASL:
+    mechanism: PLAIN
+    username: admin
+    password: mypasswordisnotsosimple


### PR DESCRIPTION
fix connection when use SASL PLAINTEXT; The doc is here [authentication_sasl_plain Doc](https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html)